### PR TITLE
Fix SciSpaCy dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ tests = [
     "pandas",
     "httpx",
     "bioregistry>=0.12.19",
+    "en-core-sci-sm @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_sm-0.5.4.tar.gz ; python_version < '3.11'"
 ]
 docs = [
     "sphinx>=8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,14 +138,6 @@ scispacy = [
     # spacy hasn't been updated to link properly to new numpy
     "numpy<2.0 ; python_version < '3.11'",
 ]
-en-core-sci-sm = [
-    "ssslm[scispacy]",
-    "en-core-sci-sm @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_sm-0.5.4.tar.gz ; python_version < '3.11'",
-]
-en-core-sci-md = [
-    "ssslm[scispacy]",
-    "en-core-sci-md @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_md-0.5.4.tar.gz ; python_version < '3.11'",
-]
 web = [
     "fastapi",
     "uvicorn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,12 @@ tests = [
     "pandas",
     "httpx",
     "bioregistry>=0.12.19",
-    "en-core-sci-sm @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_sm-0.5.4.tar.gz ; python_version < '3.11'"
+]
+en-core-sci-sm = [
+    "en-core-sci-sm @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_sm-0.5.4.tar.gz ; python_version < '3.11'",
+]
+en-core-sci-md = [
+    "en-core-sci-md @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_md-0.5.4.tar.gz ; python_version < '3.11'",
 ]
 docs = [
     "sphinx>=8",

--- a/src/ssslm/ner.py
+++ b/src/ssslm/ner.py
@@ -396,7 +396,7 @@ class SpacyGrounder(Grounder, WrappedMatcher):
             self.spacy_language_model = spacy_model
 
     def annotate(self, text: str, **kwargs: Any) -> list[Annotation]:
-        """Annotate the text using a combination of the spacy annotator, and the grounder."""
+        """Annotate the text using a combination of the spacy annotator, and the wrapped matcher."""
         document: spacy.tokens.Doc = self.spacy_language_model(text)
         return [
             Annotation(text=text, match=match, start=entity.start_char, end=entity.end_char)

--- a/src/ssslm/ner.py
+++ b/src/ssslm/ner.py
@@ -367,7 +367,8 @@ class SpacyGrounder(Grounder, WrappedMatcher):
 
         In the following example, a SpaCy grounder is instantiated using an underlying
         Gilda matcher, which incorporates the disease branch of Medical Subject Headings
-        (MeSH):
+        (MeSH). You'll need to install a SciSpaCy model first with
+        ``pip install https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_sm-0.5.4.tar.gz``.
 
         .. code-block:: python
 

--- a/src/ssslm/ner.py
+++ b/src/ssslm/ner.py
@@ -367,8 +367,8 @@ class SpacyGrounder(Grounder, WrappedMatcher):
 
         In the following example, a SpaCy grounder is instantiated using an underlying
         Gilda matcher, which incorporates the disease branch of Medical Subject Headings
-        (MeSH). You'll need to install a SciSpaCy model first with
-        ``pip install https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_sm-0.5.4.tar.gz``.
+        (MeSH). You'll need to install a SciSpaCy model first with ``pip install
+        https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_sm-0.5.4.tar.gz``.
 
         .. code-block:: python
 

--- a/tox.ini
+++ b/tox.ini
@@ -127,6 +127,7 @@ description = Run the mypy tool to check static typing on the project. Installs 
 extras =
     web
     gilda-slim
+    scispacy
 dependency_groups =
     typing
 commands = mypy --ignore-missing-imports --strict src/ tests/

--- a/tox.ini
+++ b/tox.ini
@@ -38,11 +38,12 @@ commands =
     coverage run -p -m pytest --durations=20 {posargs:tests}
     coverage combine
     coverage xml
+deps =
+    en-core-sci-sm @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_sm-0.5.4.tar.gz
 extras =
     gilda-slim
     gilda-default
     web
-    en-core-sci-sm
 # See the [dependency-groups] entry in pyproject.toml for "tests"
 dependency_groups =
     tests

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ extras =
 # See the [dependency-groups] entry in pyproject.toml for "tests"
 dependency_groups =
     tests
+    en-core-sci-sm
 
 [testenv:coverage-clean]
 description = Remove testing coverage artifacts.

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
     coverage combine
     coverage xml
 deps =
-    en-core-sci-sm @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_sm-0.5.4.tar.gz
+    en-core-sci-sm @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_sm-0.5.4.tar.gz ; python_version < '3.11'
 extras =
     gilda-slim
     gilda-default

--- a/tox.ini
+++ b/tox.ini
@@ -38,12 +38,11 @@ commands =
     coverage run -p -m pytest --durations=20 {posargs:tests}
     coverage combine
     coverage xml
-deps =
-    en-core-sci-sm @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.5.4/en_core_sci_sm-0.5.4.tar.gz ; python_version < '3.11'
 extras =
     gilda-slim
     gilda-default
     web
+    scispacy
 # See the [dependency-groups] entry in pyproject.toml for "tests"
 dependency_groups =
     tests
@@ -127,7 +126,6 @@ description = Run the mypy tool to check static typing on the project. Installs 
 extras =
     web
     gilda-slim
-    scispacy
 dependency_groups =
     typing
 commands = mypy --ignore-missing-imports --strict src/ tests/


### PR DESCRIPTION
PyPI rejects the dependencies that have direct links, so this removes them and adds different ways of specifying them in the tox config