### PR TITLE
Switch from tox to just for running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
       - name: Test with pytest and generate coverage file
         run:
-          uvx -p ${{ matrix.python-version }} --with tox-uv tox -e py
+          uvx -p ${{ matrix.python-version }} --from rust-just just test
       - name: Run doctests
         run:
           uvx -p ${{ matrix.python-version }} --with tox-uv tox -e doctests

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
 test:
     just _cov erase
     uvx --from coverage[toml] coverage erase
-    uv run --group tests --extra rdflib --extra web --extra gilda-slim --extra pandas --extra gliner --extra ontology -m coverage run -p -m pytest
+    uv run --group tests --all-extras --no-extra scispacy --no-extra gilda -m coverage run -p -m pytest
     # uv run --isolated --group tests --extra scispacy --group en-core-sci-sm -m coverage run -p -m pytest
     just _cov combine
     just _cov report

--- a/justfile
+++ b/justfile
@@ -1,7 +1,12 @@
+[doc("run tests")]
 test:
+    just _cov erase
     uvx --from coverage[toml] coverage erase
-    uv run --isolated --group tests --extra rdflib --extra web --extra gilda-slim --extra pandas --extra gliner -m coverage run -p -m pytest
+    uv run --isolated --group tests --extra rdflib --extra web --extra gilda-slim --extra pandas --extra gliner --extra ontology -m coverage run -p -m pytest
     # uv run --isolated --group tests --extra scispacy --group en-core-sci-sm -m coverage run -p -m pytest
-    uvx --from coverage[toml] coverage combine
-    uvx --from coverage[toml] coverage report
-    uvx --from coverage[toml] coverage html
+    just _cov combine
+    just _cov report
+    just _cov html
+
+_cov command:
+    uvx --from coverage[toml] coverage {{command}}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,7 @@
+test:
+    uvx --from coverage[toml] coverage erase
+    uv run --isolated --group tests --extra rdflib --extra web --extra gilda-slim --extra pandas --extra gliner -m coverage run -p -m pytest
+    # uv run --isolated --group tests --extra scispacy --group en-core-sci-sm -m coverage run -p -m pytest
+    uvx --from coverage[toml] coverage combine
+    uvx --from coverage[toml] coverage report
+    uvx --from coverage[toml] coverage html

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
 test:
     just _cov erase
     uvx --from coverage[toml] coverage erase
-    uv run --isolated --group tests --extra rdflib --extra web --extra gilda-slim --extra pandas --extra gliner --extra ontology -m coverage run -p -m pytest
+    uv run --group tests --extra rdflib --extra web --extra gilda-slim --extra pandas --extra gliner --extra ontology -m coverage run -p -m pytest
     # uv run --isolated --group tests --extra scispacy --group en-core-sci-sm -m coverage run -p -m pytest
     just _cov combine
     just _cov report

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-[doc("run tests")]
+[doc("run unit and integration tests")]
 test:
     just coverage erase
     uv run --group tests --all-extras --no-extra scispacy --no-extra gilda -m coverage run -p -m pytest

--- a/justfile
+++ b/justfile
@@ -1,12 +1,12 @@
 [doc("run tests")]
 test:
-    just _cov erase
-    uvx --from coverage[toml] coverage erase
+    just coverage erase
     uv run --group tests --all-extras --no-extra scispacy --no-extra gilda -m coverage run -p -m pytest
-    # uv run --isolated --group tests --extra scispacy --group en-core-sci-sm -m coverage run -p -m pytest
-    just _cov combine
-    just _cov report
-    just _cov html
+    # skip scispacy tests for now
+    just coverage combine
+    just coverage report
+    just coverage html
 
-_cov command:
+[doc("run `coverage` with a given subcommand")]
+@coverage command:
     uvx --from coverage[toml] coverage {{command}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ web = [
 ]
 pandas = [
     "pandas",
+    "numpy>=2.0.0",
 ]
 rdflib = [
     "rdflib",
@@ -159,6 +160,13 @@ ontology = [
     "bioregistry",
 ]
 
+[tool.uv]
+conflicts = [
+    [
+      { extra = "pandas" },
+      { extra = "scispacy" },
+    ],
+]
 
 # See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls
 # and also https://packaging.python.org/en/latest/specifications/well-known-project-urls/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,10 @@ conflicts = [
       { extra = "pandas" },
       { extra = "scispacy" },
     ],
+    [
+      { extra = "gilda-slim" },
+      { extra = "gilda" },
+    ],
 ]
 
 # See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls

--- a/src/ssslm/ontology.py
+++ b/src/ssslm/ontology.py
@@ -186,7 +186,8 @@ def _iter_prefix_map(
             except ImportError:
                 raise ImportError(
                     "Can not automatically look up URI prefixes when outputting SSSLM as RDF "
-                    "because the Bioregistry is not installed.\n\n\tpip install bioregistry"
+                    "because the Bioregistry is not installed.\n\n\tpip install ssslm[ontology]"
+                    "\n\nOR, instally it directly with\n\n\tpip install bioregistry"
                 ) from None
             resource = bioregistry.get_resource(prefix, strict=True)
             uri_prefix = resource.rdf_uri_format or resource.get_uri_prefix()

--- a/tox.ini
+++ b/tox.ini
@@ -31,25 +31,9 @@ envlist =
     coverage-report
 
 [testenv]
-description = Run unit and integration tests.
-# Runs on the "tests" directory by default, or passes the positional
-# arguments from `tox -e py <posargs_1> ... <posargs_n>
-commands =
-    coverage run -p -m pytest --durations=20 {posargs:tests}
-    coverage combine
-    coverage xml
-extras =
-    gilda-slim
-    web
-    scispacy
-    gliner
-    rdflib
-    ontology
-    pandas
-# See the [dependency-groups] entry in pyproject.toml for "tests"
-dependency_groups =
-    tests
-    en-core-sci-sm
+skip_install = true
+commands = just test
+allowlist_externals = just
 
 [testenv:coverage-clean]
 description = Remove testing coverage artifacts.

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ commands = coverage erase
 
 [testenv:doctests]
 description = Test that documentation examples run properly.
+skip_install = false
 commands =
     # note that the package name is required for discovery
     xdoctest -m src/ssslm
@@ -51,6 +52,7 @@ dependency_groups =
 
 [testenv:treon]
 description = Test that notebooks can run to completion
+skip_install = false
 commands =
     treon notebooks/
 deps =
@@ -116,6 +118,7 @@ extras =
     gilda-slim
 dependency_groups =
     typing
+skip_install = false
 commands = mypy --ignore-missing-imports --strict src/ tests/
 
 [testenv:docs-lint]
@@ -140,6 +143,7 @@ dependency_groups =
     # See the [dependency-groups] entry in pyproject.toml for "docs"
     docs
     # You might need to add additional extras if your documentation covers it
+skip_install = false
 commands =
     python -m sphinx -b html -d docs/build/doctrees docs/source docs/build/html
 
@@ -148,6 +152,7 @@ description = Test building the documentation in an isolated environment. Warnin
 changedir = docs
 dependency_groups =
     {[testenv:docs]dependency_groups}
+skip_install = false
 commands =
     mkdir -p {envtmpdir}
     cp -r source {envtmpdir}/source


### PR DESCRIPTION
Getting here involved some creative restructuring of the extras, dependencies, and making explicit some conflicts caused by scispacy. Since scispacy only works on old python with numpy<2, so I had to include an explicit dependency in the `pandas` group on numpy>=2 and then make explicit the dependency conflicts to uv